### PR TITLE
Add description to 'xgboost-model'

### DIFF
--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -6,6 +6,7 @@ randomforest-model:
   path: .mlem/model/clf-model
   type: model
 xgboost-model:
+  description: Customer Churn Classifier Model
   labels:
   - classification
   - churn


### PR DESCRIPTION
Adds a GTO description to the `xgboost-model` in the `artifacts.yaml` file.